### PR TITLE
Dev/use dataclass to replace pydantic

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,21 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:abd51e72c0717ff1b734c1afa0aaef578744eaeba6e9cc17d48977258f598757"
-
-[[package]]
-name = "annotated-types"
-version = "0.5.0"
-requires_python = ">=3.7"
-summary = "Reusable constraint types to use with typing.Annotated"
-groups = ["default"]
-dependencies = [
-    "typing-extensions>=4.0.0; python_version < \"3.9\"",
-]
-files = [
-    {file = "annotated_types-0.5.0-py3-none-any.whl", hash = "sha256:58da39888f92c276ad970249761ebea80ba544b77acddaa1a4d6cf78287d45fd"},
-    {file = "annotated_types-0.5.0.tar.gz", hash = "sha256:47cdc3490d9ac1506ce92c7aaa76c579dc3509ff11e098fc867e5130ab7be802"},
-]
+content_hash = "sha256:86e29cc35d1f2dcba10dff12e97c6d32a2fecb796d51b77e039dc3b2af680d78"
 
 [[package]]
 name = "colorama"
@@ -161,6 +147,16 @@ files = [
 ]
 
 [[package]]
+name = "dacite"
+version = "1.8.1"
+requires_python = ">=3.6"
+summary = "Simple creation of data classes from dictionaries."
+groups = ["default"]
+files = [
+    {file = "dacite-1.8.1-py3-none-any.whl", hash = "sha256:cc31ad6fdea1f49962ea42db9421772afe01ac5442380d9a99fcf3d188c61afe"},
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.2.0"
 requires_python = ">=3.7"
@@ -269,115 +265,6 @@ dependencies = [
 files = [
     {file = "portalocker-2.8.2-py3-none-any.whl", hash = "sha256:cfb86acc09b9aa7c3b43594e19be1345b9d16af3feb08bf92f23d4dce513a28e"},
     {file = "portalocker-2.8.2.tar.gz", hash = "sha256:2b035aa7828e46c58e9b31390ee1f169b98e1066ab10b9a6a861fe7e25ee4f33"},
-]
-
-[[package]]
-name = "pydantic"
-version = "2.5.3"
-requires_python = ">=3.7"
-summary = "Data validation using Python type hints"
-groups = ["default"]
-dependencies = [
-    "annotated-types>=0.4.0",
-    "pydantic-core==2.14.6",
-    "typing-extensions>=4.6.1",
-]
-files = [
-    {file = "pydantic-2.5.3-py3-none-any.whl", hash = "sha256:d0caf5954bee831b6bfe7e338c32b9e30c85dfe080c843680783ac2b631673b4"},
-    {file = "pydantic-2.5.3.tar.gz", hash = "sha256:b3ef57c62535b0941697cce638c08900d87fcb67e29cfa99e8a68f747f393f7a"},
-]
-
-[[package]]
-name = "pydantic-core"
-version = "2.14.6"
-requires_python = ">=3.7"
-summary = ""
-groups = ["default"]
-dependencies = [
-    "typing-extensions!=4.7.0,>=4.6.0",
-]
-files = [
-    {file = "pydantic_core-2.14.6-cp310-cp310-macosx_10_7_x86_64.whl", hash = "sha256:72f9a942d739f09cd42fffe5dc759928217649f070056f03c70df14f5770acf9"},
-    {file = "pydantic_core-2.14.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6a31d98c0d69776c2576dda4b77b8e0c69ad08e8b539c25c7d0ca0dc19a50d6c"},
-    {file = "pydantic_core-2.14.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5aa90562bc079c6c290f0512b21768967f9968e4cfea84ea4ff5af5d917016e4"},
-    {file = "pydantic_core-2.14.6-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:370ffecb5316ed23b667d99ce4debe53ea664b99cc37bfa2af47bc769056d534"},
-    {file = "pydantic_core-2.14.6-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f85f3843bdb1fe80e8c206fe6eed7a1caeae897e496542cee499c374a85c6e08"},
-    {file = "pydantic_core-2.14.6-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9862bf828112e19685b76ca499b379338fd4c5c269d897e218b2ae8fcb80139d"},
-    {file = "pydantic_core-2.14.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:036137b5ad0cb0004c75b579445a1efccd072387a36c7f217bb8efd1afbe5245"},
-    {file = "pydantic_core-2.14.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:92879bce89f91f4b2416eba4429c7b5ca22c45ef4a499c39f0c5c69257522c7c"},
-    {file = "pydantic_core-2.14.6-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:0c08de15d50fa190d577e8591f0329a643eeaed696d7771760295998aca6bc66"},
-    {file = "pydantic_core-2.14.6-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:36099c69f6b14fc2c49d7996cbf4f87ec4f0e66d1c74aa05228583225a07b590"},
-    {file = "pydantic_core-2.14.6-cp310-none-win32.whl", hash = "sha256:7be719e4d2ae6c314f72844ba9d69e38dff342bc360379f7c8537c48e23034b7"},
-    {file = "pydantic_core-2.14.6-cp310-none-win_amd64.whl", hash = "sha256:36fa402dcdc8ea7f1b0ddcf0df4254cc6b2e08f8cd80e7010d4c4ae6e86b2a87"},
-    {file = "pydantic_core-2.14.6-cp311-cp311-macosx_10_7_x86_64.whl", hash = "sha256:dea7fcd62915fb150cdc373212141a30037e11b761fbced340e9db3379b892d4"},
-    {file = "pydantic_core-2.14.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ffff855100bc066ff2cd3aa4a60bc9534661816b110f0243e59503ec2df38421"},
-    {file = "pydantic_core-2.14.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1b027c86c66b8627eb90e57aee1f526df77dc6d8b354ec498be9a757d513b92b"},
-    {file = "pydantic_core-2.14.6-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:00b1087dabcee0b0ffd104f9f53d7d3eaddfaa314cdd6726143af6bc713aa27e"},
-    {file = "pydantic_core-2.14.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:75ec284328b60a4e91010c1acade0c30584f28a1f345bc8f72fe8b9e46ec6a96"},
-    {file = "pydantic_core-2.14.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7e1f4744eea1501404b20b0ac059ff7e3f96a97d3e3f48ce27a139e053bb370b"},
-    {file = "pydantic_core-2.14.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b2602177668f89b38b9f84b7b3435d0a72511ddef45dc14446811759b82235a1"},
-    {file = "pydantic_core-2.14.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6c8edaea3089bf908dd27da8f5d9e395c5b4dc092dbcce9b65e7156099b4b937"},
-    {file = "pydantic_core-2.14.6-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:478e9e7b360dfec451daafe286998d4a1eeaecf6d69c427b834ae771cad4b622"},
-    {file = "pydantic_core-2.14.6-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:b6ca36c12a5120bad343eef193cc0122928c5c7466121da7c20f41160ba00ba2"},
-    {file = "pydantic_core-2.14.6-cp311-none-win32.whl", hash = "sha256:2b8719037e570639e6b665a4050add43134d80b687288ba3ade18b22bbb29dd2"},
-    {file = "pydantic_core-2.14.6-cp311-none-win_amd64.whl", hash = "sha256:78ee52ecc088c61cce32b2d30a826f929e1708f7b9247dc3b921aec367dc1b23"},
-    {file = "pydantic_core-2.14.6-cp311-none-win_arm64.whl", hash = "sha256:a19b794f8fe6569472ff77602437ec4430f9b2b9ec7a1105cfd2232f9ba355e6"},
-    {file = "pydantic_core-2.14.6-cp312-cp312-macosx_10_7_x86_64.whl", hash = "sha256:667aa2eac9cd0700af1ddb38b7b1ef246d8cf94c85637cbb03d7757ca4c3fdec"},
-    {file = "pydantic_core-2.14.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cdee837710ef6b56ebd20245b83799fce40b265b3b406e51e8ccc5b85b9099b7"},
-    {file = "pydantic_core-2.14.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c5bcf3414367e29f83fd66f7de64509a8fd2368b1edf4351e862910727d3e51"},
-    {file = "pydantic_core-2.14.6-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:26a92ae76f75d1915806b77cf459811e772d8f71fd1e4339c99750f0e7f6324f"},
-    {file = "pydantic_core-2.14.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a983cca5ed1dd9a35e9e42ebf9f278d344603bfcb174ff99a5815f953925140a"},
-    {file = "pydantic_core-2.14.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cb92f9061657287eded380d7dc455bbf115430b3aa4741bdc662d02977e7d0af"},
-    {file = "pydantic_core-2.14.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4ace1e220b078c8e48e82c081e35002038657e4b37d403ce940fa679e57113b"},
-    {file = "pydantic_core-2.14.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ef633add81832f4b56d3b4c9408b43d530dfca29e68fb1b797dcb861a2c734cd"},
-    {file = "pydantic_core-2.14.6-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:7e90d6cc4aad2cc1f5e16ed56e46cebf4877c62403a311af20459c15da76fd91"},
-    {file = "pydantic_core-2.14.6-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:e8a5ac97ea521d7bde7621d86c30e86b798cdecd985723c4ed737a2aa9e77d0c"},
-    {file = "pydantic_core-2.14.6-cp312-none-win32.whl", hash = "sha256:f27207e8ca3e5e021e2402ba942e5b4c629718e665c81b8b306f3c8b1ddbb786"},
-    {file = "pydantic_core-2.14.6-cp312-none-win_amd64.whl", hash = "sha256:b3e5fe4538001bb82e2295b8d2a39356a84694c97cb73a566dc36328b9f83b40"},
-    {file = "pydantic_core-2.14.6-cp312-none-win_arm64.whl", hash = "sha256:64634ccf9d671c6be242a664a33c4acf12882670b09b3f163cd00a24cffbd74e"},
-    {file = "pydantic_core-2.14.6-cp39-cp39-macosx_10_7_x86_64.whl", hash = "sha256:4ce8299b481bcb68e5c82002b96e411796b844d72b3e92a3fbedfe8e19813eab"},
-    {file = "pydantic_core-2.14.6-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b9a9d92f10772d2a181b5ca339dee066ab7d1c9a34ae2421b2a52556e719756f"},
-    {file = "pydantic_core-2.14.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fd9e98b408384989ea4ab60206b8e100d8687da18b5c813c11e92fd8212a98e0"},
-    {file = "pydantic_core-2.14.6-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4f86f1f318e56f5cbb282fe61eb84767aee743ebe32c7c0834690ebea50c0a6b"},
-    {file = "pydantic_core-2.14.6-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:86ce5fcfc3accf3a07a729779d0b86c5d0309a4764c897d86c11089be61da160"},
-    {file = "pydantic_core-2.14.6-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3dcf1978be02153c6a31692d4fbcc2a3f1db9da36039ead23173bc256ee3b91b"},
-    {file = "pydantic_core-2.14.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eedf97be7bc3dbc8addcef4142f4b4164066df0c6f36397ae4aaed3eb187d8ab"},
-    {file = "pydantic_core-2.14.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d5f916acf8afbcab6bacbb376ba7dc61f845367901ecd5e328fc4d4aef2fcab0"},
-    {file = "pydantic_core-2.14.6-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:8a14c192c1d724c3acbfb3f10a958c55a2638391319ce8078cb36c02283959b9"},
-    {file = "pydantic_core-2.14.6-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:0348b1dc6b76041516e8a854ff95b21c55f5a411c3297d2ca52f5528e49d8411"},
-    {file = "pydantic_core-2.14.6-cp39-none-win32.whl", hash = "sha256:de2a0645a923ba57c5527497daf8ec5df69c6eadf869e9cd46e86349146e5975"},
-    {file = "pydantic_core-2.14.6-cp39-none-win_amd64.whl", hash = "sha256:aca48506a9c20f68ee61c87f2008f81f8ee99f8d7f0104bff3c47e2d148f89d9"},
-    {file = "pydantic_core-2.14.6-pp310-pypy310_pp73-macosx_10_7_x86_64.whl", hash = "sha256:d5c28525c19f5bb1e09511669bb57353d22b94cf8b65f3a8d141c389a55dec95"},
-    {file = "pydantic_core-2.14.6-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:78d0768ee59baa3de0f4adac9e3748b4b1fffc52143caebddfd5ea2961595277"},
-    {file = "pydantic_core-2.14.6-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b93785eadaef932e4fe9c6e12ba67beb1b3f1e5495631419c784ab87e975670"},
-    {file = "pydantic_core-2.14.6-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a874f21f87c485310944b2b2734cd6d318765bcbb7515eead33af9641816506e"},
-    {file = "pydantic_core-2.14.6-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b89f4477d915ea43b4ceea6756f63f0288941b6443a2b28c69004fe07fde0d0d"},
-    {file = "pydantic_core-2.14.6-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:172de779e2a153d36ee690dbc49c6db568d7b33b18dc56b69a7514aecbcf380d"},
-    {file = "pydantic_core-2.14.6-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:dfcebb950aa7e667ec226a442722134539e77c575f6cfaa423f24371bb8d2e94"},
-    {file = "pydantic_core-2.14.6-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:55a23dcd98c858c0db44fc5c04fc7ed81c4b4d33c653a7c45ddaebf6563a2f66"},
-    {file = "pydantic_core-2.14.6-pp37-pypy37_pp73-macosx_10_7_x86_64.whl", hash = "sha256:4241204e4b36ab5ae466ecec5c4c16527a054c69f99bba20f6f75232a6a534e2"},
-    {file = "pydantic_core-2.14.6-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e574de99d735b3fc8364cba9912c2bec2da78775eba95cbb225ef7dda6acea24"},
-    {file = "pydantic_core-2.14.6-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1302a54f87b5cd8528e4d6d1bf2133b6aa7c6122ff8e9dc5220fbc1e07bffebd"},
-    {file = "pydantic_core-2.14.6-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f8e81e4b55930e5ffab4a68db1af431629cf2e4066dbdbfef65348b8ab804ea8"},
-    {file = "pydantic_core-2.14.6-pp37-pypy37_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c99462ffc538717b3e60151dfaf91125f637e801f5ab008f81c402f1dff0cd0f"},
-    {file = "pydantic_core-2.14.6-pp37-pypy37_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:e4cf2d5829f6963a5483ec01578ee76d329eb5caf330ecd05b3edd697e7d768a"},
-    {file = "pydantic_core-2.14.6-pp38-pypy38_pp73-macosx_10_7_x86_64.whl", hash = "sha256:cf10b7d58ae4a1f07fccbf4a0a956d705356fea05fb4c70608bb6fa81d103cda"},
-    {file = "pydantic_core-2.14.6-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:399ac0891c284fa8eb998bcfa323f2234858f5d2efca3950ae58c8f88830f145"},
-    {file = "pydantic_core-2.14.6-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c6a5c79b28003543db3ba67d1df336f253a87d3112dac3a51b94f7d48e4c0e1"},
-    {file = "pydantic_core-2.14.6-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:599c87d79cab2a6a2a9df4aefe0455e61e7d2aeede2f8577c1b7c0aec643ee8e"},
-    {file = "pydantic_core-2.14.6-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:43e166ad47ba900f2542a80d83f9fc65fe99eb63ceec4debec160ae729824052"},
-    {file = "pydantic_core-2.14.6-pp38-pypy38_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:3a0b5db001b98e1c649dd55afa928e75aa4087e587b9524a4992316fa23c9fba"},
-    {file = "pydantic_core-2.14.6-pp38-pypy38_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:747265448cb57a9f37572a488a57d873fd96bf51e5bb7edb52cfb37124516da4"},
-    {file = "pydantic_core-2.14.6-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:7ebe3416785f65c28f4f9441e916bfc8a54179c8dea73c23023f7086fa601c5d"},
-    {file = "pydantic_core-2.14.6-pp39-pypy39_pp73-macosx_10_7_x86_64.whl", hash = "sha256:86c963186ca5e50d5c8287b1d1c9d3f8f024cbe343d048c5bd282aec2d8641f2"},
-    {file = "pydantic_core-2.14.6-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:e0641b506486f0b4cd1500a2a65740243e8670a2549bb02bc4556a83af84ae03"},
-    {file = "pydantic_core-2.14.6-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71d72ca5eaaa8d38c8df16b7deb1a2da4f650c41b58bb142f3fb75d5ad4a611f"},
-    {file = "pydantic_core-2.14.6-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27e524624eace5c59af499cd97dc18bb201dc6a7a2da24bfc66ef151c69a5f2a"},
-    {file = "pydantic_core-2.14.6-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a3dde6cac75e0b0902778978d3b1646ca9f438654395a362cb21d9ad34b24acf"},
-    {file = "pydantic_core-2.14.6-pp39-pypy39_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:00646784f6cd993b1e1c0e7b0fdcbccc375d539db95555477771c27555e3c556"},
-    {file = "pydantic_core-2.14.6-pp39-pypy39_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:23598acb8ccaa3d1d875ef3b35cb6376535095e9405d91a3d57a8c7db5d29341"},
-    {file = "pydantic_core-2.14.6-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7f41533d7e3cf9520065f610b41ac1c76bc2161415955fbcead4981b22c7611e"},
-    {file = "pydantic_core-2.14.6.tar.gz", hash = "sha256:1fd0c1d395372843fba13a51c28e3bb9d59bd7aebfeb17358ffaaa1e4dbbe948"},
 ]
 
 [[package]]
@@ -491,7 +378,7 @@ name = "typing-extensions"
 version = "4.7.1"
 requires_python = ">=3.7"
 summary = "Backported and Experimental Type Hints for Python 3.7+"
-groups = ["default", "dev"]
+groups = ["dev"]
 files = [
     {file = "typing_extensions-4.7.1-py3-none-any.whl", hash = "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36"},
     {file = "typing_extensions-4.7.1.tar.gz", hash = "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "testsolar-testtool-sdk"
-version = "0.1.2"
+version = "0.1.3"
 description = "TestSolar测试工具SDK"
 authors = [
     {name = "asiazhang", email = "asiazhang2002@gmail.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ authors = [
     {name = "asiazhang", email = "asiazhang2002@gmail.com"},
 ]
 dependencies = [
-    "pydantic>=2.1.1",
     "portalocker>=2.8.2",
+    "dacite>=1.8.1",
 ]
 requires-python = ">=3.8"
 readme = "README.md"

--- a/src/testsolar_testtool_sdk/model/encoder.py
+++ b/src/testsolar_testtool_sdk/model/encoder.py
@@ -1,0 +1,16 @@
+import json
+import datetime
+
+from typing import Any
+
+
+class DateTimeEncoder(json.JSONEncoder):
+    def default(self, obj) -> Any:
+        if isinstance(obj, datetime.datetime):
+            return _format_datetime(obj)
+        else:
+            return super().default(obj)
+
+
+def _format_datetime(t: datetime) -> str:
+    return t.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"

--- a/src/testsolar_testtool_sdk/model/encoder.py
+++ b/src/testsolar_testtool_sdk/model/encoder.py
@@ -1,12 +1,12 @@
 import json
-import datetime
+from datetime import datetime
 
 from typing import Any
 
 
 class DateTimeEncoder(json.JSONEncoder):
     def default(self, obj) -> Any:
-        if isinstance(obj, datetime.datetime):
+        if isinstance(obj, datetime):
             return _format_datetime(obj)
         else:
             return super().default(obj)

--- a/src/testsolar_testtool_sdk/model/load.py
+++ b/src/testsolar_testtool_sdk/model/load.py
@@ -1,15 +1,17 @@
 from typing import List
 
-from pydantic import BaseModel, Field
-
 from .test import TestCase
 
+from dataclasses import dataclass, field
 
-class LoadError(BaseModel):
+
+@dataclass(frozen=True)
+class LoadError:
     name: str
     message: str
 
 
-class LoadResult(BaseModel):
-    tests: List[TestCase] = Field(alias="Tests")
-    load_errors: List[LoadError] = Field(alias="LoadErrors")
+@dataclass
+class LoadResult:
+    Tests: List[TestCase] = field(default_factory=list)
+    LoadErrors: List[LoadError] = field(default_factory=list)

--- a/src/testsolar_testtool_sdk/model/param.py
+++ b/src/testsolar_testtool_sdk/model/param.py
@@ -1,12 +1,13 @@
 from typing import Dict, List
 
-from pydantic import BaseModel, Field
+from dataclasses import dataclass, field
 
 
-class EntryParam(BaseModel):
-    context: Dict[str, str] = Field(alias="Context")
-    task_id: str = Field(alias="TaskId")
-    project_path: str = Field(alias="ProjectPath")
-    test_selectors: List[str] = Field(alias="TestSelectors")
-    collectors: List[str] = Field(alias="Collectors")
-    fileReportPath: str = Field(alias="FileReportPath")
+@dataclass(frozen=True)
+class EntryParam:
+    TaskId: str
+    ProjectPath: str
+    FileReportPath: str
+    Collectors: List[str] = field(default_factory=list)
+    Context: Dict[str, str] = field(default_factory=dict)
+    TestSelectors: List[str] = field(default_factory=list)

--- a/src/testsolar_testtool_sdk/model/test.py
+++ b/src/testsolar_testtool_sdk/model/test.py
@@ -1,10 +1,11 @@
 from typing import Dict
 
-from pydantic import BaseModel, Field
+from dataclasses import dataclass, field
 
 
-class TestCase(BaseModel):
+@dataclass(frozen=True)
+class TestCase:
     __test__ = False
 
-    name: str = Field(alias="Name")
-    attrs: Dict[str, str] = Field(alias="Attributes")
+    Name: str
+    Attributes: Dict[str, str] = field(default_factory=dict)

--- a/src/testsolar_testtool_sdk/model/testresult.py
+++ b/src/testsolar_testtool_sdk/model/testresult.py
@@ -1,8 +1,7 @@
+from dataclasses import dataclass, field
+from datetime import datetime
 from enum import Enum
 from typing import List, Optional
-from datetime import datetime
-
-from pydantic import BaseModel, Field
 
 from .test import TestCase
 
@@ -31,72 +30,59 @@ class AttachmentType(str, Enum):
     IFRAME = "IFRAME"
 
 
-class TestCaseAssertError(BaseModel):
+@dataclass(frozen=True)
+class TestCaseAssertError:
     __test__ = False
 
-    expect: str = Field(alias="Expect")
-    actual: str = Field(alias="Actual")
-    message: str = Field(alias="Message")
+    Expect: str
+    Actual: str
+    Message: str
 
 
-class TestCaseRuntimeError(BaseModel):
+@dataclass(frozen=True)
+class TestCaseRuntimeError:
     __test__ = False
 
-    summary: str = Field(alias="Summary")
-    detail: str = Field(alias="Detail")
+    Summary: str
+    Detail: str
 
 
-class Attachment(BaseModel):
-    name: str = Field(alias="Name")
-    url: str = Field(alias="Url")
-    type: AttachmentType = Field(alias="AttachmentType")
+@dataclass(frozen=True)
+class Attachment:
+    Name: str
+    Url: str
+    AttachmentType: AttachmentType
 
 
-class TestCaseLog(BaseModel):
+@dataclass
+class TestCaseLog:
     __test__ = False
 
-    time: datetime = Field(alias="Time")
-    level: LogLevel = Field(alias="Level")
-    content: str = Field(alias="Content")
-    attachments: List[Attachment] = Field(alias="Attachments")
-    assert_error: TestCaseAssertError = Field(alias="AssertError")
-    runtime_error: Optional[TestCaseRuntimeError] = Field(None, alias="RuntimeError")
-
-    class Config:
-        json_encoders = {
-            datetime: lambda dt: _format_datetime(dt),
-        }
+    Time: datetime
+    Level: LogLevel
+    Content: str
+    AssertError: Optional[TestCaseAssertError] = None
+    RuntimeError: Optional[TestCaseRuntimeError] = None
+    Attachments: List[Attachment] = field(default_factory=list)
 
 
-class TestCaseStep(BaseModel):
+@dataclass
+class TestCaseStep:
     __test__ = False
 
-    start_time: datetime = Field(alias="StartTime")
-    end_time: Optional[datetime] = Field(alias="EndTime")
-    title: str = Field(alias="Title")
-    logs: List[TestCaseLog] = Field(alias="Logs")
-
-    class Config:
-        json_encoders = {
-            datetime: lambda dt: _format_datetime(dt),
-        }
+    StartTime: datetime
+    Title: str
+    EndTime: Optional[datetime] = None
+    Logs: List[TestCaseLog] = field(default_factory=list)
 
 
-def _format_datetime(t: datetime) -> str:
-    return t.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
-
-
-class TestResult(BaseModel):
+@dataclass
+class TestResult:
     __test__ = False
 
-    test: TestCase = Field(alias="Test")
-    start_time: datetime = Field(alias="StartTime")
-    end_time: Optional[datetime] = Field(alias="EndTime")
-    result_type: ResultType = Field(alias="ResultType")
-    message: str = Field(alias="Message")
-    steps: List[TestCaseStep] = Field(alias="Steps")
-
-    class Config:
-        json_encoders = {
-            datetime: lambda dt: _format_datetime(dt),
-        }
+    Test: TestCase
+    StartTime: datetime
+    ResultType: ResultType
+    Message: str
+    EndTime: Optional[datetime] = None
+    Steps: List[TestCaseStep] = field(default_factory=list)

--- a/src/testsolar_testtool_sdk/pipe_reader.py
+++ b/src/testsolar_testtool_sdk/pipe_reader.py
@@ -1,5 +1,8 @@
+import json
 import struct
 from typing import BinaryIO
+
+from dacite import from_dict, Config
 
 from .model.load import LoadResult
 from .model.testresult import TestResult
@@ -10,14 +13,18 @@ from .reporter import MAGIC_NUMBER
 def read_load_result(pipe_io: BinaryIO) -> LoadResult:
     result_data = _read_model(pipe_io)
 
-    re = LoadResult.model_validate_json(result_data)
+    data_dict: dict = json.loads(result_data)
+    re: LoadResult = from_dict(data_class=LoadResult, data=data_dict)
+
     return re
 
 
 # 从管道读取测试用例结果，仅供单元测试使用
 def read_test_result(pipe_io: BinaryIO) -> TestResult:
     result_data = _read_model(pipe_io)
-    re = TestResult.model_validate_json(result_data)
+
+    data_dict: dict = json.loads(result_data)
+    re: TestResult = from_dict(data_class=TestResult, data=data_dict, config=Config(check_types=False))
     return re
 
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,4 +1,5 @@
 import concurrent.futures
+import dataclasses
 import io
 import json
 import logging
@@ -7,6 +8,7 @@ from datetime import datetime, timedelta
 from functools import partial
 from typing import BinaryIO
 
+from src.testsolar_testtool_sdk.model.encoder import DateTimeEncoder
 from src.testsolar_testtool_sdk.model.load import LoadResult, LoadError
 from src.testsolar_testtool_sdk.model.test import TestCase
 from src.testsolar_testtool_sdk.model.testresult import ResultType, LogLevel
@@ -27,14 +29,14 @@ def generate_demo_load_result() -> LoadResult:
     r: LoadResult = LoadResult(Tests=[], LoadErrors=[])
 
     for x in range(40):
-        r.tests.append(
+        r.Tests.append(
             TestCase(
                 Name=f"mumu/mu.py/test_case_name_{x}_p1", Attributes={"tag": "P1"}
             )
         )
 
     for x in range(20):
-        r.load_errors.append(
+        r.LoadErrors.append(
             LoadError(
                 name=f"load error {x}",
                 message=f"""
@@ -155,7 +157,7 @@ def send_test_result(pipe_io: BinaryIO):
 
 def test_datetime_formatted():
     run_case_result = generate_test_result(0)
-    data = run_case_result.model_dump_json(by_alias=True, indent=2)
+    data = json.dumps(dataclasses.asdict(run_case_result), cls=DateTimeEncoder)
     tr = json.loads(data)
     assert tr['StartTime'].endswith("Z")
     assert tr['EndTime'].endswith("Z")
@@ -180,12 +182,12 @@ def test_report_run_case_result():
     # 检查管道中的数据，确保每个用例的魔数和数据长度还有数据正确
     pipe_io.seek(0)
     r1: TestResult = read_test_result(pipe_io)
-    assert r1.result_type == ResultType.SUCCEED
+    assert r1.ResultType == ResultType.SUCCEED
     r2 = read_test_result(pipe_io)
-    assert r2.result_type == ResultType.SUCCEED
+    assert r2.ResultType == ResultType.SUCCEED
     r3 = read_test_result(pipe_io)
-    assert r3.result_type == ResultType.SUCCEED
+    assert r3.ResultType == ResultType.SUCCEED
     r4 = read_test_result(pipe_io)
-    assert r4.result_type == ResultType.SUCCEED
+    assert r4.ResultType == ResultType.SUCCEED
     r5 = read_test_result(pipe_io)
-    assert r5.result_type == ResultType.SUCCEED
+    assert r5.ResultType == ResultType.SUCCEED


### PR DESCRIPTION
- 使用`dataclass`替换`pydantic`
- 增加`dacite`用于反序列化dataclass

`dacite`仅用于测试函数，在实际执行的时候不会使用到，因此当前可能跟用户冲突的包仅有`portalocker`，概率很低。

当前仅包含以下依赖：

```
dacite 1.8.1 [ required: >=1.8.1 ]
portalocker 2.8.2 [ required: >=2.8.2 ]
```