### PR TITLE
调整上报用例结果函数名称

### DIFF
--- a/src/testsolar_testtool_sdk/reporter.py
+++ b/src/testsolar_testtool_sdk/reporter.py
@@ -42,9 +42,9 @@ class Reporter:
         with portalocker.Lock(self.lock_file, timeout=60):
             self._send_json(dataclasses.asdict(load_result))
 
-    def report_run_case_result(self, run_case_result: TestResult) -> None:
+    def report_case_result(self, case_result: TestResult) -> None:
         with portalocker.Lock(self.lock_file, timeout=60):
-            self._send_json(dataclasses.asdict(run_case_result))
+            self._send_json(dataclasses.asdict(case_result))
 
     def close(self) -> None:
         if self.pipe_io:

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -150,7 +150,7 @@ def send_test_result(reporter: Reporter):
     test_results = []
     run_case_result = generate_test_result(0)
     test_results.append(run_case_result)
-    reporter.report_run_case_result(run_case_result)
+    reporter.report_case_result(run_case_result)
 
 
 def test_datetime_formatted():


### PR DESCRIPTION
当前的`report_run_case_result`名称有点误导，可能会被认为是上报正在执行中的用例结果